### PR TITLE
Fix GitHub URL in install.txt

### DIFF
--- a/messages/install.txt
+++ b/messages/install.txt
@@ -7,4 +7,4 @@ This linter plugin for SublimeLinter provides an interface to php-cs-fixer.
 Before this plugin will activate, you *must*
 follow the installation instructions here:
 
-https://github.com/jhoff/SublimeLinter-php-cs-fixer
+https://github.com/jhoff/SublimeLinter-contrib-php-cs-fixer


### PR DESCRIPTION
The post install messages pointed to the wrong Github URL. Can be confusing, if you just installed the plugin and want to read about the plugins requirements.