### PR TITLE
Look for .php_cs configuration file first

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -25,12 +25,14 @@ def _find_configuration_file(file_name):
     if not len(file_name) > 0:
         return None
 
+    candidates = ['.php_cs', '.php_cs.dist']
     checked = []
     check_dir = os.path.dirname(file_name)
     while check_dir not in checked:
-        configuration_file = os.path.join(check_dir, '.php_cs')
-        if os.path.isfile(configuration_file):
-            return configuration_file
+        for candidate in candidates:
+            configuration_file = os.path.join(check_dir, candidate)
+            if os.path.isfile(configuration_file):
+                return configuration_file
 
         checked.append(check_dir)
         check_dir = os.path.dirname(check_dir)


### PR DESCRIPTION
PHP CS Fixer automatically looks for two configurations files:

1. .php_cs
2. .php_cs.dist

The first one found is the one used. This allows users to provide a
configuration (the .dist version) in the sources, and then use gitignore
to ignore the non .dist version. This means that users can override the
configuration locally without modify sources.

See https://github.com/FriendsOfPhp/PHP-CS-Fixer#config-file

> Instead of using command line options to customize the rule, you can
> save the project configuration in a .php_cs.dist file in the root
> directory of your project. The file must return an instance of
> PhpCsFixer\ConfigInterface which lets you configure the rules, the files
> and directories that need to be analyzed. You may also create .php_cs
> file, which is the local configuration that will be used instead of the
> project configuration. It is a good practice to add that file into your
> .gitignore file. With the --config option you can specify the path to
> the .php_cs file.