### PR TITLE
Update diff option to support PHP CS Fixer v3.0

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -89,7 +89,7 @@ class PhpCsFixer(Linter):
         command.append('--dry-run')
         command.append('--show-progress=none')
         command.append('--stop-on-violation')
-        command.append('--diff-format=udiff')  # requires php-cs-fixer >= 2.7
+        command.append('--diff')
         command.append('--using-cache=no')
         command.append('--no-ansi')
         command.append('-vv')


### PR DESCRIPTION
The --diff-format was removed in version 3.0, all diffs are now udiff.

https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/master/UPGRADE-v3.md

The --diff flag can be used to let the fixer output all the changes it
makes in udiff format.

Re #13

**Perhaps an option should be added to allow users to choose between support for v2 and v3?**