### PR TITLE
Add support for php-cs-fixer v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,16 @@ To install via Package Control, do the following:
 ## Settings
 For general information on how SublimeLinter works with settings, please see [Settings][settings]. For information on generic linter settings, please see [Linter Settings][linter-settings].
 
+###  PHP-CS-Fixer V2
+
+By default the plugin is configured for PHP-CS-Fixer V3. To enable V2 configure the phpcsfixer linter. Open SublimeLinter settings e.g. via the command palette *Preferences: Sublime Linter: Settings*:
+
+```
+"phpcsfixer": {
+    "version": 2
+}
+```
+
 ## Contributing
 If you would like to contribute enhancements or fixes, please do the following:
 

--- a/linter.py
+++ b/linter.py
@@ -89,7 +89,12 @@ class PhpCsFixer(Linter):
         command.append('--dry-run')
         command.append('--show-progress=none')
         command.append('--stop-on-violation')
-        command.append('--diff-format=udiff')  # requires php-cs-fixer >= 2.7
+
+        if self.settings.get('version') and self.settings.get('version') == 2:
+            command.append('--diff-format=udiff')
+        else:
+            command.append('--diff')
+
         command.append('--using-cache=no')
         command.append('--no-ansi')
         command.append('-vv')


### PR DESCRIPTION
The `--diff-format` was removed in v3, all diffs are now udiff.  The
`--diff flag` can be used to let the fixer output all the changes it
makes in udiff format.
https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/master/UPGRADE-v3.md

By default the plugin is now configured for PHP-CS-Fixer V3. To enable
V2 configure the phpcsfixer linter. Open SublimeLinter settings e.g. via
the command palette *Preferences: Sublime Linter: Settings*:

```
"phpcsfixer": {
    "version": 2
}
```

Re #13
Close #14